### PR TITLE
support custom partitioner for nebula when generate sst files

### DIFF
--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
@@ -395,7 +395,8 @@ object Configs {
         val localPath  = getOptOrElse(tagConfig, "local.path")
         val remotePath = getOptOrElse(tagConfig, "remote.path")
 
-        val partition = getOrElse(tagConfig, "partition", DEFAULT_PARTITION)
+        val partition             = getOrElse(tagConfig, "partition", DEFAULT_PARTITION)
+        val repartitionWithNebula = getOrElse(tagConfig, "repartitionWithNebula", false)
 
         LOG.info(s"name ${tagName}  batch ${batch}")
         val entry = TagConfigEntry(tagName,
@@ -407,7 +408,8 @@ object Configs {
                                    policyOpt,
                                    batch,
                                    partition,
-                                   checkPointPath)
+                                   checkPointPath,
+                                   repartitionWithNebula)
         LOG.info(s"Tag Config: ${entry}")
         tags += entry
       }
@@ -510,6 +512,8 @@ object Configs {
         val localPath  = getOptOrElse(edgeConfig, "path.local")
         val remotePath = getOptOrElse(edgeConfig, "path.remote")
 
+        val repartitionWithNebula = getOrElse(edgeConfig, "repartitionWithNebula", false)
+
         val entry = EdgeConfigEntry(
           edgeName,
           sourceConfig,
@@ -526,7 +530,8 @@ object Configs {
           longitude,
           batch,
           partition,
-          checkPointPath
+          checkPointPath,
+          repartitionWithNebula
         )
         LOG.info(s"Edge Config: ${entry}")
         edges += entry

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SchemaConfigs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SchemaConfigs.scala
@@ -59,7 +59,8 @@ case class TagConfigEntry(override val name: String,
                           vertexPolicy: Option[KeyPolicy.Value],
                           override val batch: Int,
                           override val partition: Int,
-                          override val checkPointPath: Option[String])
+                          override val checkPointPath: Option[String],
+                          repartitionWithNebula: Boolean = false)
     extends SchemaConfigEntry {
   require(name.trim.nonEmpty && vertexField.trim.nonEmpty && batch > 0)
 
@@ -108,7 +109,8 @@ case class EdgeConfigEntry(override val name: String,
                            longitude: Option[String],
                            override val batch: Int,
                            override val partition: Int,
-                           override val checkPointPath: Option[String])
+                           override val checkPointPath: Option[String],
+                           repartitionWithNebula: Boolean = false)
     extends SchemaConfigEntry {
   require(
     name.trim.nonEmpty && sourceField.trim.nonEmpty &&

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SinkConfigs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SinkConfigs.scala
@@ -32,8 +32,12 @@ case class FileBaseSinkConfigEntry(override val category: SinkCategory.Value,
                                    remotePath: String,
                                    fsName: Option[String])
     extends DataSinkConfigEntry {
+
   override def toString: String = {
-    s"File sink: from ${localPath} to ${fsName.get}${remotePath}"
+    val fullRemotePath =
+      if (fsName.isDefined) s"${fsName.get}$remotePath"
+      else remotePath
+    s"File sink: from ${localPath} to $fullRemotePath"
   }
 }
 

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/processor/Processor.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/processor/Processor.scala
@@ -233,11 +233,10 @@ trait Processor extends Serializable {
 
   def customRepartition(spark: SparkSession,
                         data: Dataset[(Array[Byte], Array[Byte])],
-                        partitionNum: Int,
-                        vidType: VidType.Value): Dataset[(Array[Byte], Array[Byte])] = {
+                        partitionNum: Int): Dataset[(Array[Byte], Array[Byte])] = {
     import spark.implicits._
     data.rdd
-      .partitionBy(new NebulaPartitioner(partitionNum, vidType))
+      .partitionBy(new NebulaPartitioner(partitionNum))
       .map(kv => SSTData(kv._1, kv._2))
       .toDF()
       .map { row =>

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/utils/NebulaPartitioner.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/utils/NebulaPartitioner.scala
@@ -1,0 +1,19 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package com.vesoft.exchange.common.utils
+
+import com.vesoft.exchange.common.VidType
+import org.apache.spark.Partitioner
+
+class NebulaPartitioner(partitions: Int, vidType: VidType.Value) extends Partitioner {
+  require(partitions >= 0, s"Number of partitions ($partitions) cannot be negative.")
+
+  override def numPartitions: Int = partitions
+
+  override def getPartition(key: Any): Int = {
+    NebulaUtils.getPartitionId(key.toString, partitions, vidType) - 1
+  }
+}

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/writer/FileBaseWriter.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/writer/FileBaseWriter.scala
@@ -19,9 +19,8 @@ import org.slf4j.LoggerFactory
 /**
   * NebulaSSTWriter
   */
-class NebulaSSTWriter extends Writer {
-  var isOpen       = false
-  var path: String = _
+class NebulaSSTWriter(path: String) extends Writer {
+  var isOpen = false
 
   private val LOG = LoggerFactory.getLogger(getClass)
 
@@ -39,11 +38,6 @@ class NebulaSSTWriter extends Writer {
 
   val env                   = new EnvOptions()
   var writer: SstFileWriter = _
-
-  def withPath(path: String): NebulaSSTWriter = {
-    this.path = path
-    this
-  }
 
   override def prepare(): Unit = {
     writer = new SstFileWriter(env, options)
@@ -63,6 +57,11 @@ class NebulaSSTWriter extends Writer {
     options.close()
     env.close()
   }
+
+}
+
+class GenerateSstFile {
+  private val LOG = LoggerFactory.getLogger(getClass)
 
   def writeSstFiles(iterator: Iterator[Row],
                     fileBaseConfig: FileBaseSinkConfigEntry,
@@ -97,7 +96,8 @@ class NebulaSSTWriter extends Writer {
           }
           currentPart = part
           val tmp = s"$localPath/$currentPart-$taskID.sst"
-          withPath(tmp).prepare()
+          writer = new NebulaSSTWriter(tmp)
+          writer.prepare()
         }
         writer.write(key, value)
       }

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/writer/FileBaseWriter.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/writer/FileBaseWriter.scala
@@ -60,7 +60,7 @@ class NebulaSSTWriter(path: String) extends Writer {
 
 }
 
-class GenerateSstFile {
+class GenerateSstFile extends Serializable {
   private val LOG = LoggerFactory.getLogger(getClass)
 
   def writeSstFiles(iterator: Iterator[Row],

--- a/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/FileBaseWriterSuite.scala
+++ b/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/FileBaseWriterSuite.scala
@@ -1,0 +1,8 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+ 
+package com.vesoft.exchange.common.writer class FileBaseWriterSuite {
+
+}

--- a/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/FileBaseWriterSuite.scala
+++ b/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/FileBaseWriterSuite.scala
@@ -2,7 +2,49 @@
  *
  * This source code is licensed under Apache 2.0 License.
  */
- 
-package com.vesoft.exchange.common.writer class FileBaseWriterSuite {
+
+package com.vesoft.exchange.common.writer
+
+import com.vesoft.exchange.common.config.{FileBaseSinkConfigEntry, SinkCategory}
+import org.apache.spark.sql.{Dataset, Encoders, Row, SparkSession}
+import org.junit.Test
+
+class FileBaseWriterSuite {
+
+  @Test
+  def writeSstFilesSuite(): Unit = {
+    val spark = SparkSession.builder().master("local").getOrCreate()
+    import spark.implicits._
+    // generate byte[] key using encoder's getVertexKey, space:"test", tag: "person"
+    val key1  = "01a40200310000000000000000000000000000000000000002000000" // id: "1"
+    val key2  = "01170000320000000000000000000000000000000000000002000000" // id: "2"
+    val key3  = "01fe0000330000000000000000000000000000000000000002000000" // id: "3"
+    val key4  = "01a90300340000000000000000000000000000000000000002000000" // id: "4"
+    val key5  = "01220200350000000000000000000000000000000000000002000000" // id: "5"
+    val value = "abc"
+    // construct test dataset
+    val data: Dataset[(Array[Byte], Array[Byte])] = spark.sparkContext
+      .parallelize(
+        List(key1.getBytes(), key2.getBytes(), key3.getBytes(), key4.getBytes(), key5.getBytes()))
+      .map(line => (line, value.getBytes()))
+      .toDF("key", "value")
+      .map { row =>
+        (row.getAs[Array[Byte]](0), row.getAs[Array[Byte]](1))
+      }(Encoders.tuple(Encoders.BINARY, Encoders.BINARY))
+
+    val generateSstFile = new GenerateSstFile
+
+    val fileBaseConfig =
+      FileBaseSinkConfigEntry(SinkCategory.SST, "/tmp", "/tmp/remote", None)
+    val batchFailure = spark.sparkContext.longAccumulator(s"batchFailure.test}")
+
+    data
+      .toDF("key", "value")
+      .sortWithinPartitions("key")
+      .foreachPartition { iterator: Iterator[Row] =>
+        generateSstFile.writeSstFiles(iterator, fileBaseConfig, 10, null, batchFailure)
+      }
+    assert(batchFailure.value == 0)
+  }
 
 }

--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
@@ -140,13 +140,15 @@ object Exchange {
             spark.sparkContext.longAccumulator(s"batchFailure.${tagConfig.name}")
 
           val processor = new VerticesProcessor(
+            spark,
             repartition(data.get, tagConfig.partition, tagConfig.dataSourceConfigEntry.category),
             tagConfig,
             fieldKeys,
             nebulaKeys,
             configs,
             batchSuccess,
-            batchFailure)
+            batchFailure
+          )
           processor.process()
           val costTime = ((System.currentTimeMillis() - startTime) / 1000.0).formatted("%.2f")
           LOG.info(s"import for tag ${tagConfig.name} cost time: ${costTime} s")
@@ -185,6 +187,7 @@ object Exchange {
           val batchFailure = spark.sparkContext.longAccumulator(s"batchFailure.${edgeConfig.name}")
 
           val processor = new EdgeProcessor(
+            spark,
             repartition(data.get, edgeConfig.partition, edgeConfig.dataSourceConfigEntry.category),
             edgeConfig,
             fieldKeys,

--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -19,7 +19,7 @@ import com.vesoft.exchange.common.config.{
 import com.vesoft.exchange.common.processor.Processor
 import com.vesoft.exchange.common.utils.NebulaUtils
 import com.vesoft.exchange.common.utils.NebulaUtils.DEFAULT_EMPTY_VALUE
-import com.vesoft.exchange.common.writer.{NebulaGraphClientWriter, NebulaSSTWriter}
+import com.vesoft.exchange.common.writer.{GenerateSstFile, NebulaGraphClientWriter, NebulaSSTWriter}
 import com.vesoft.exchange.common.VidType
 import com.vesoft.nebula.encoder.NebulaCodecImpl
 import com.vesoft.nebula.meta.EdgeItem
@@ -123,19 +123,22 @@ class EdgeProcessor(spark: SparkSession,
         .flatMap(line => {
           List((line._1, line._3), (line._2, line._3))
         })(Encoders.tuple(Encoders.BINARY, Encoders.BINARY))
+
+      // repartition dataframe according to nebula part, to make sure sst files for one part has no overlap
       if (edgeConfig.repartitionWithNebula) {
-        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum, vidType)
+        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum)
       }
+
       sstKeyValueData
         .toDF("key", "value")
         .sortWithinPartitions("key")
         .foreachPartition { iterator: Iterator[Row] =>
-          val sstFileWriter = new NebulaSSTWriter
-          sstFileWriter.writeSstFiles(iterator,
-                                      fileBaseConfig,
-                                      partitionNum,
-                                      namenode,
-                                      batchFailure)
+          val generateSstFile = new GenerateSstFile
+          generateSstFile.writeSstFiles(iterator,
+                                        fileBaseConfig,
+                                        partitionNum,
+                                        namenode,
+                                        batchFailure)
         }
     } else {
       val streamFlag = data.isStreaming

--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -25,7 +25,7 @@ import com.vesoft.nebula.meta.TagItem
 import org.apache.commons.codec.digest.MurmurHash2
 import org.apache.log4j.Logger
 import org.apache.spark.TaskContext
-import org.apache.spark.sql.{DataFrame, Encoders, Row}
+import org.apache.spark.sql.{DataFrame, Encoders, Row, SparkSession}
 import org.apache.spark.util.LongAccumulator
 
 import scala.collection.JavaConverters._
@@ -41,7 +41,8 @@ import scala.collection.mutable.ArrayBuffer
   * @param batchSuccess
   * @param batchFailure
   */
-class VerticesProcessor(data: DataFrame,
+class VerticesProcessor(spark: SparkSession,
+                        data: DataFrame,
                         tagConfig: TagConfigEntry,
                         fieldKeys: List[String],
                         nebulaKeys: List[String],

--- a/nebula-exchange_spark_2.2/src/test/scala/com/vesoft/nebula/exchange/processor/EdgeProcessorSuite.scala
+++ b/nebula-exchange_spark_2.2/src/test/scala/com/vesoft/nebula/exchange/processor/EdgeProcessorSuite.scala
@@ -67,7 +67,7 @@ class EdgeProcessorSuite {
                         "col14")
 
   val processClazz =
-    new EdgeProcessor(data, edgeConfig, fieldKeys, nebulaKeys, config, null, null)
+    new EdgeProcessor(null, data, edgeConfig, fieldKeys, nebulaKeys, config, null, null)
   @Test
   def isEdgeValidSuite(): Unit = {
     val stringIdValue = List("Bob", "Tom")

--- a/nebula-exchange_spark_2.2/src/test/scala/com/vesoft/nebula/exchange/processor/VerticesProcessorSuite.scala
+++ b/nebula-exchange_spark_2.2/src/test/scala/com/vesoft/nebula/exchange/processor/VerticesProcessorSuite.scala
@@ -67,7 +67,7 @@ class VerticesProcessorSuite {
                         "col14")
 
   val processClazz =
-    new VerticesProcessor(data, tagConfig, fieldKeys, nebulaKeys, config, null, null)
+    new VerticesProcessor(null, data, tagConfig, fieldKeys, nebulaKeys, config, null, null)
   @Test
   def isVertexValidSuite(): Unit = {
     val stringIdValue      = List("Bob")

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
@@ -140,13 +140,15 @@ object Exchange {
             spark.sparkContext.longAccumulator(s"batchFailure.${tagConfig.name}")
 
           val processor = new VerticesProcessor(
+            spark,
             repartition(data.get, tagConfig.partition, tagConfig.dataSourceConfigEntry.category),
             tagConfig,
             fieldKeys,
             nebulaKeys,
             configs,
             batchSuccess,
-            batchFailure)
+            batchFailure
+          )
           processor.process()
           val costTime = ((System.currentTimeMillis() - startTime) / 1000.0).formatted("%.2f")
           LOG.info(s"import for tag ${tagConfig.name} cost time: ${costTime} s")
@@ -185,6 +187,7 @@ object Exchange {
           val batchFailure = spark.sparkContext.longAccumulator(s"batchFailure.${edgeConfig.name}")
 
           val processor = new EdgeProcessor(
+            spark,
             repartition(data.get, edgeConfig.partition, edgeConfig.dataSourceConfigEntry.category),
             edgeConfig,
             fieldKeys,

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -20,7 +20,7 @@ import com.vesoft.exchange.common.config.{
 import com.vesoft.exchange.common.processor.Processor
 import com.vesoft.exchange.common.utils.NebulaUtils
 import com.vesoft.exchange.common.utils.NebulaUtils.DEFAULT_EMPTY_VALUE
-import com.vesoft.exchange.common.writer.{NebulaGraphClientWriter, NebulaSSTWriter}
+import com.vesoft.exchange.common.writer.{GenerateSstFile, NebulaGraphClientWriter, NebulaSSTWriter}
 import com.vesoft.exchange.common.VidType
 import com.vesoft.nebula.encoder.NebulaCodecImpl
 import com.vesoft.nebula.meta.EdgeItem
@@ -125,20 +125,22 @@ class EdgeProcessor(spark: SparkSession,
         .flatMap(line => {
           List((line._1, line._3), (line._2, line._3))
         })(Encoders.tuple(Encoders.BINARY, Encoders.BINARY))
+
       // repartition dataframe according to nebula part, to make sure sst files for one part has no overlap
       if (edgeConfig.repartitionWithNebula) {
-        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum, vidType)
+        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum)
       }
+
       sstKeyValueData
         .toDF("key", "value")
         .sortWithinPartitions("key")
         .foreachPartition { iterator: Iterator[Row] =>
-          val sstFileWriter = new NebulaSSTWriter
-          sstFileWriter.writeSstFiles(iterator,
-                                      fileBaseConfig,
-                                      partitionNum,
-                                      namenode,
-                                      batchFailure)
+          val generateSstFile = new GenerateSstFile
+          generateSstFile.writeSstFiles(iterator,
+                                        fileBaseConfig,
+                                        partitionNum,
+                                        namenode,
+                                        batchFailure)
         }
     } else {
       val streamFlag = data.isStreaming

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -28,13 +28,14 @@ import org.apache.commons.codec.digest.MurmurHash2
 import org.apache.log4j.Logger
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.streaming.Trigger
-import org.apache.spark.sql.{DataFrame, Encoders, Row}
+import org.apache.spark.sql.{DataFrame, Encoders, Row, SparkSession}
 import org.apache.spark.util.LongAccumulator
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
-class EdgeProcessor(data: DataFrame,
+class EdgeProcessor(spark: SparkSession,
+                    data: DataFrame,
                     edgeConfig: EdgeConfigEntry,
                     fieldKeys: List[String],
                     nebulaKeys: List[String],
@@ -114,7 +115,8 @@ class EdgeProcessor(data: DataFrame,
       } else {
         data.dropDuplicates(edgeConfig.sourceField, edgeConfig.targetField)
       }
-      distintData
+
+      var sstKeyValueData = distintData
         .mapPartitions { iter =>
           iter.map { row =>
             encodeEdge(row, partitionNum, vidType, spaceVidLen, edgeItem, fieldTypeMap)
@@ -123,6 +125,11 @@ class EdgeProcessor(data: DataFrame,
         .flatMap(line => {
           List((line._1, line._3), (line._2, line._3))
         })(Encoders.tuple(Encoders.BINARY, Encoders.BINARY))
+      // repartition dataframe according to nebula part, to make sure sst files for one part has no overlap
+      if (edgeConfig.repartitionWithNebula) {
+        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum, vidType)
+      }
+      sstKeyValueData
         .toDF("key", "value")
         .sortWithinPartitions("key")
         .foreachPartition { iterator: Iterator[Row] =>

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -19,7 +19,7 @@ import com.vesoft.exchange.common.config.{
 import com.vesoft.exchange.common.processor.{Processor, SSTData}
 import com.vesoft.exchange.common.utils.{NebulaPartitioner, NebulaUtils}
 import com.vesoft.exchange.common.utils.NebulaUtils.DEFAULT_EMPTY_VALUE
-import com.vesoft.exchange.common.writer.{NebulaGraphClientWriter, NebulaSSTWriter}
+import com.vesoft.exchange.common.writer.{GenerateSstFile, NebulaGraphClientWriter, NebulaSSTWriter}
 import com.vesoft.exchange.common.VidType
 import com.vesoft.nebula.encoder.NebulaCodecImpl
 import com.vesoft.nebula.meta.TagItem
@@ -126,18 +126,19 @@ class VerticesProcessor(spark: SparkSession,
 
       // repartition dataframe according to nebula part, to make sure sst files for one part has no overlap
       if (tagConfig.repartitionWithNebula) {
-        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum, vidType)
+        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum)
       }
+
       sstKeyValueData
         .toDF("key", "value")
         .sortWithinPartitions("key")
         .foreachPartition { iterator: Iterator[Row] =>
-          val sstFileWriter = new NebulaSSTWriter
-          sstFileWriter.writeSstFiles(iterator,
-                                      fileBaseConfig,
-                                      partitionNum,
-                                      namenode,
-                                      batchFailure)
+          val generateSstFile = new GenerateSstFile
+          generateSstFile.writeSstFiles(iterator,
+                                        fileBaseConfig,
+                                        partitionNum,
+                                        namenode,
+                                        batchFailure)
         }
     } else {
       val streamFlag = data.isStreaming

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -16,8 +16,8 @@ import com.vesoft.exchange.common.config.{
   StreamingDataSourceConfigEntry,
   TagConfigEntry
 }
-import com.vesoft.exchange.common.processor.Processor
-import com.vesoft.exchange.common.utils.NebulaUtils
+import com.vesoft.exchange.common.processor.{Processor, SSTData}
+import com.vesoft.exchange.common.utils.{NebulaPartitioner, NebulaUtils}
 import com.vesoft.exchange.common.utils.NebulaUtils.DEFAULT_EMPTY_VALUE
 import com.vesoft.exchange.common.writer.{NebulaGraphClientWriter, NebulaSSTWriter}
 import com.vesoft.exchange.common.VidType
@@ -27,7 +27,7 @@ import org.apache.commons.codec.digest.MurmurHash2
 import org.apache.log4j.Logger
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.streaming.Trigger
-import org.apache.spark.sql.{DataFrame, Encoders, Row}
+import org.apache.spark.sql.{DataFrame, Encoders, Row, SparkSession}
 import org.apache.spark.util.LongAccumulator
 
 import scala.collection.JavaConverters._
@@ -43,7 +43,8 @@ import scala.collection.mutable.ArrayBuffer
   * @param batchSuccess
   * @param batchFailure
   */
-class VerticesProcessor(data: DataFrame,
+class VerticesProcessor(spark: SparkSession,
+                        data: DataFrame,
                         tagConfig: TagConfigEntry,
                         fieldKeys: List[String],
                         nebulaKeys: List[String],
@@ -115,13 +116,19 @@ class VerticesProcessor(data: DataFrame,
       val spaceVidLen = metaProvider.getSpaceVidLen(space)
       val tagItem     = metaProvider.getTagItem(space, tagName)
 
-      data
+      var sstKeyValueData = data
         .dropDuplicates(tagConfig.vertexField)
         .mapPartitions { iter =>
           iter.map { row =>
             encodeVertex(row, partitionNum, vidType, spaceVidLen, tagItem, fieldTypeMap)
           }
         }(Encoders.tuple(Encoders.BINARY, Encoders.BINARY))
+
+      // repartition dataframe according to nebula part, to make sure sst files for one part has no overlap
+      if (tagConfig.repartitionWithNebula) {
+        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum, vidType)
+      }
+      sstKeyValueData
         .toDF("key", "value")
         .sortWithinPartitions("key")
         .foreachPartition { iterator: Iterator[Row] =>

--- a/nebula-exchange_spark_2.4/src/test/scala/com/vesoft/nebula/exchange/processor/EdgeProcessorSuite.scala
+++ b/nebula-exchange_spark_2.4/src/test/scala/com/vesoft/nebula/exchange/processor/EdgeProcessorSuite.scala
@@ -68,7 +68,7 @@ class EdgeProcessorSuite {
                         "col14")
 
   val processClazz =
-    new EdgeProcessor(data, edgeConfig, fieldKeys, nebulaKeys, config, null, null)
+    new EdgeProcessor(null, data, edgeConfig, fieldKeys, nebulaKeys, config, null, null)
   @Test
   def isEdgeValidSuite(): Unit = {
     val stringIdValue = List("Bob", "Tom")

--- a/nebula-exchange_spark_2.4/src/test/scala/com/vesoft/nebula/exchange/processor/VerticesProcessorSuite.scala
+++ b/nebula-exchange_spark_2.4/src/test/scala/com/vesoft/nebula/exchange/processor/VerticesProcessorSuite.scala
@@ -68,7 +68,7 @@ class VerticesProcessorSuite {
                         "col14")
 
   val processClazz =
-    new VerticesProcessor(data, tagConfig, fieldKeys, nebulaKeys, config, null, null)
+    new VerticesProcessor(null, data, tagConfig, fieldKeys, nebulaKeys, config, null, null)
   @Test
   def isVertexValidSuite(): Unit = {
     val stringIdValue      = List("Bob")

--- a/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
+++ b/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
@@ -140,13 +140,15 @@ object Exchange {
             spark.sparkContext.longAccumulator(s"batchFailure.${tagConfig.name}")
 
           val processor = new VerticesProcessor(
+            spark,
             repartition(data.get, tagConfig.partition, tagConfig.dataSourceConfigEntry.category),
             tagConfig,
             fieldKeys,
             nebulaKeys,
             configs,
             batchSuccess,
-            batchFailure)
+            batchFailure
+          )
           processor.process()
           val costTime = ((System.currentTimeMillis() - startTime) / 1000.0).formatted("%.2f")
           LOG.info(s"import for tag ${tagConfig.name} cost time: ${costTime} s")
@@ -185,6 +187,7 @@ object Exchange {
           val batchFailure = spark.sparkContext.longAccumulator(s"batchFailure.${edgeConfig.name}")
 
           val processor = new EdgeProcessor(
+            spark,
             repartition(data.get, edgeConfig.partition, edgeConfig.dataSourceConfigEntry.category),
             edgeConfig,
             fieldKeys,

--- a/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -28,13 +28,14 @@ import org.apache.commons.codec.digest.MurmurHash2
 import org.apache.log4j.Logger
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.streaming.Trigger
-import org.apache.spark.sql.{DataFrame, Dataset, Encoders, Row}
+import org.apache.spark.sql.{DataFrame, Dataset, Encoders, Row, SparkSession}
 import org.apache.spark.util.LongAccumulator
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
-class EdgeProcessor(data: DataFrame,
+class EdgeProcessor(spark: SparkSession,
+                    data: DataFrame,
                     edgeConfig: EdgeConfigEntry,
                     fieldKeys: List[String],
                     nebulaKeys: List[String],
@@ -114,7 +115,7 @@ class EdgeProcessor(data: DataFrame,
       } else {
         data.dropDuplicates(edgeConfig.sourceField, edgeConfig.targetField)
       }
-      distintData
+      var sstKeyValueData = distintData
         .mapPartitions { iter =>
           iter.map { row =>
             encodeEdge(row, partitionNum, vidType, spaceVidLen, edgeItem, fieldTypeMap)
@@ -123,6 +124,10 @@ class EdgeProcessor(data: DataFrame,
         .flatMap(line => {
           List((line._1, line._3), (line._2, line._3))
         })(Encoders.tuple(Encoders.BINARY, Encoders.BINARY))
+      if (edgeConfig.repartitionWithNebula) {
+        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum, vidType)
+      }
+      sstKeyValueData
         .toDF("key", "value")
         .sortWithinPartitions("key")
         .foreachPartition { iterator: Iterator[Row] =>

--- a/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -19,7 +19,7 @@ import com.vesoft.exchange.common.config.{
 import com.vesoft.exchange.common.processor.Processor
 import com.vesoft.exchange.common.utils.NebulaUtils
 import com.vesoft.exchange.common.utils.NebulaUtils.DEFAULT_EMPTY_VALUE
-import com.vesoft.exchange.common.writer.{NebulaGraphClientWriter, NebulaSSTWriter}
+import com.vesoft.exchange.common.writer.{GenerateSstFile, NebulaGraphClientWriter, NebulaSSTWriter}
 import com.vesoft.exchange.common.VidType
 import com.vesoft.nebula.encoder.NebulaCodecImpl
 import com.vesoft.nebula.meta.TagItem
@@ -123,19 +123,22 @@ class VerticesProcessor(spark: SparkSession,
             encodeVertex(row, partitionNum, vidType, spaceVidLen, tagItem, fieldTypeMap)
           }
         }(Encoders.tuple(Encoders.BINARY, Encoders.BINARY))
+
+      // repartition dataframe according to nebula part, to make sure sst files for one part has no overlap
       if (tagConfig.repartitionWithNebula) {
-        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum, vidType)
+        sstKeyValueData = customRepartition(spark, sstKeyValueData, partitionNum)
       }
+
       sstKeyValueData
         .toDF("key", "value")
         .sortWithinPartitions("key")
         .foreachPartition { iterator: Iterator[Row] =>
-          val sstFileWriter = new NebulaSSTWriter
-          sstFileWriter.writeSstFiles(iterator,
-                                      fileBaseConfig,
-                                      partitionNum,
-                                      namenode,
-                                      batchFailure)
+          val generateSstFile = new GenerateSstFile
+          generateSstFile.writeSstFiles(iterator,
+                                        fileBaseConfig,
+                                        partitionNum,
+                                        namenode,
+                                        batchFailure)
         }
     } else {
       val streamFlag = data.isStreaming

--- a/nebula-exchange_spark_3.0/src/test/scala/com/vesoft/nebula/exchange/processor/EdgeProcessorSuite.scala
+++ b/nebula-exchange_spark_3.0/src/test/scala/com/vesoft/nebula/exchange/processor/EdgeProcessorSuite.scala
@@ -67,7 +67,7 @@ class EdgeProcessorSuite {
                         "col14")
 
   val processClazz =
-    new EdgeProcessor(data, edgeConfig, fieldKeys, nebulaKeys, config, null, null)
+    new EdgeProcessor(null, data, edgeConfig, fieldKeys, nebulaKeys, config, null, null)
   @Test
   def isEdgeValidSuite(): Unit = {
     val stringIdValue = List("Bob", "Tom")

--- a/nebula-exchange_spark_3.0/src/test/scala/com/vesoft/nebula/exchange/processor/VerticesProcessorSuite.scala
+++ b/nebula-exchange_spark_3.0/src/test/scala/com/vesoft/nebula/exchange/processor/VerticesProcessorSuite.scala
@@ -67,7 +67,7 @@ class VerticesProcessorSuite {
                         "col14")
 
   val processClazz =
-    new VerticesProcessor(data, tagConfig, fieldKeys, nebulaKeys, config, null, null)
+    new VerticesProcessor(null, data, tagConfig, fieldKeys, nebulaKeys, config, null, null)
   @Test
   def isVertexValidSuite(): Unit = {
     val stringIdValue      = List("Bob")

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,10 @@
                 <artifactId>guava</artifactId>
                 <groupId>com.google.guava</groupId>
             </exclusion>
+            <exclusion>
+                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+            </exclusion>
         </exclusions>
     </dependency>
 </dependencies>


### PR DESCRIPTION
1. whether to use custom partitioner is configurable.
2. use custom partitioner make sure the keys in different sst files does not overlap.
3. When ingest sst files generated with custom partitioner, all most sst files lies on L6 (space is empty before ingest).
![image](https://user-images.githubusercontent.com/16240361/148155905-03180dfd-4a90-44ed-911b-b7d658aba3e3.png)

The configure is useful only when the first full importing. 