### PR TITLE
remove extra space for string value for postgresql datasource

### DIFF
--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -193,7 +193,7 @@ class EdgeProcessor(spark: SparkSession,
       if (index < 0 || row.isNullAt(index)) {
         printChoice(streamFlag, s"rank must exist and cannot be null, your row data is $row")
       }
-      val ranking = row.get(index).toString
+      val ranking = row.get(index).toString.trim
       if (!NebulaUtils.isNumic(ranking)) {
         printChoice(streamFlag,
                     s"Not support non-Numeric type for ranking field.your row data is $row")
@@ -221,7 +221,7 @@ class EdgeProcessor(spark: SparkSession,
       if (index < 0 || row.isNullAt(index)) {
         printChoice(streamFlag, s"$fieldType must exist and cannot be null, your row data is $row")
         None
-      } else Some(row.get(index).toString)
+      } else Some(row.get(index).toString.trim)
     }
 
     val idFlag = fieldValue.isDefined
@@ -267,7 +267,7 @@ class EdgeProcessor(spark: SparkSession,
 
     if (edgeConfig.rankingField.isDefined) {
       val index   = row.schema.fieldIndex(edgeConfig.rankingField.get)
-      val ranking = row.get(index).toString
+      val ranking = row.get(index).toString.trim
       Edge(sourceField, targetField, Some(ranking.toLong), values)
     } else {
       Edge(sourceField, targetField, None, values)
@@ -288,7 +288,7 @@ class EdgeProcessor(spark: SparkSession,
       indexCells(lat, lng).mkString(",")
     } else {
       val index = row.schema.fieldIndex(field)
-      val value = row.get(index).toString
+      val value = row.get(index).toString.trim
       if (value.equals(DEFAULT_EMPTY_VALUE)) "" else value
     }
     // process string type vid
@@ -310,11 +310,11 @@ class EdgeProcessor(spark: SparkSession,
     isEdgeValid(row, edgeConfig, false, vidType == VidType.STRING)
 
     val srcIndex: Int = row.schema.fieldIndex(edgeConfig.sourceField)
-    var srcId: String = row.get(srcIndex).toString
+    var srcId: String = row.get(srcIndex).toString.trim
     if (srcId.equals(DEFAULT_EMPTY_VALUE)) { srcId = "" }
 
     val dstIndex: Int = row.schema.fieldIndex(edgeConfig.targetField)
-    var dstId: String = row.get(dstIndex).toString
+    var dstId: String = row.get(dstIndex).toString.trim
     if (dstId.equals(DEFAULT_EMPTY_VALUE)) { dstId = "" }
 
     if (edgeConfig.sourcePolicy.isDefined) {
@@ -344,7 +344,7 @@ class EdgeProcessor(spark: SparkSession,
 
     val ranking: Long = if (edgeConfig.rankingField.isDefined) {
       val rankIndex = row.schema.fieldIndex(edgeConfig.rankingField.get)
-      row.get(rankIndex).toString.toLong
+      row.get(rankIndex).toString.trim.toLong
     } else {
       0
     }

--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -176,7 +176,7 @@ class VerticesProcessor(spark: SparkSession,
       return false
     }
 
-    val vertexId = row.get(index).toString
+    val vertexId = row.get(index).toString.trim
     // process int type vid
     if (tagConfig.vertexPolicy.isEmpty && !isVidStringType && !NebulaUtils.isNumic(vertexId)) {
       printChoice(
@@ -203,7 +203,7 @@ class VerticesProcessor(spark: SparkSession,
                       fieldKeys: List[String],
                       fieldTypeMap: Map[String, Int]): Vertex = {
     val index    = row.schema.fieldIndex(tagConfig.vertexField)
-    var vertexId = row.get(index).toString
+    var vertexId = row.get(index).toString.trim
     if (vertexId.equals(DEFAULT_EMPTY_VALUE)) {
       vertexId = ""
     }
@@ -231,7 +231,7 @@ class VerticesProcessor(spark: SparkSession,
     isVertexValid(row, tagConfig, false, vidType == VidType.STRING)
 
     val index: Int       = row.schema.fieldIndex(tagConfig.vertexField)
-    var vertexId: String = row.get(index).toString
+    var vertexId: String = row.get(index).toString.trim
     if (vertexId.equals(DEFAULT_EMPTY_VALUE)) {
       vertexId = ""
     }

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -212,7 +212,7 @@ class EdgeProcessor(spark: SparkSession,
       if (index < 0 || row.isNullAt(index)) {
         printChoice(streamFlag, s"rank must exist and cannot be null, your row data is $row")
       }
-      val ranking = row.get(index).toString
+      val ranking = row.get(index).toString.trim
       if (!NebulaUtils.isNumic(ranking)) {
         printChoice(streamFlag,
                     s"Not support non-Numeric type for ranking field.your row data is $row")
@@ -240,7 +240,7 @@ class EdgeProcessor(spark: SparkSession,
       if (index < 0 || row.isNullAt(index)) {
         printChoice(streamFlag, s"$fieldType must exist and cannot be null, your row data is $row")
         None
-      } else Some(row.get(index).toString)
+      } else Some(row.get(index).toString.trim)
     }
 
     val idFlag = fieldValue.isDefined
@@ -286,7 +286,7 @@ class EdgeProcessor(spark: SparkSession,
 
     if (edgeConfig.rankingField.isDefined) {
       val index   = row.schema.fieldIndex(edgeConfig.rankingField.get)
-      val ranking = row.get(index).toString
+      val ranking = row.get(index).toString.trim
       Edge(sourceField, targetField, Some(ranking.toLong), values)
     } else {
       Edge(sourceField, targetField, None, values)
@@ -307,7 +307,7 @@ class EdgeProcessor(spark: SparkSession,
       indexCells(lat, lng).mkString(",")
     } else {
       val index = row.schema.fieldIndex(field)
-      val value = row.get(index).toString
+      val value = row.get(index).toString.trim
       if (value.equals(DEFAULT_EMPTY_VALUE)) "" else value
     }
     // process string type vid
@@ -329,13 +329,13 @@ class EdgeProcessor(spark: SparkSession,
     isEdgeValid(row, edgeConfig, false, vidType == VidType.STRING)
 
     val srcIndex: Int = row.schema.fieldIndex(edgeConfig.sourceField)
-    var srcId: String = row.get(srcIndex).toString
+    var srcId: String = row.get(srcIndex).toString.trim
     if (srcId.equals(DEFAULT_EMPTY_VALUE)) {
       srcId = ""
     }
 
     val dstIndex: Int = row.schema.fieldIndex(edgeConfig.targetField)
-    var dstId: String = row.get(dstIndex).toString
+    var dstId: String = row.get(dstIndex).toString.trim
     if (dstId.equals(DEFAULT_EMPTY_VALUE)) {
       dstId = ""
     }
@@ -367,7 +367,7 @@ class EdgeProcessor(spark: SparkSession,
 
     val ranking: Long = if (edgeConfig.rankingField.isDefined) {
       val rankIndex = row.schema.fieldIndex(edgeConfig.rankingField.get)
-      row.get(rankIndex).toString.toLong
+      row.get(rankIndex).toString.trim.toLong
     } else {
       0
     }

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -195,7 +195,7 @@ class VerticesProcessor(spark: SparkSession,
       return false
     }
 
-    val vertexId = row.get(index).toString
+    val vertexId = row.get(index).toString.trim
     // process int type vid
     if (tagConfig.vertexPolicy.isEmpty && !isVidStringType && !NebulaUtils.isNumic(vertexId)) {
       printChoice(
@@ -222,7 +222,7 @@ class VerticesProcessor(spark: SparkSession,
                       fieldKeys: List[String],
                       fieldTypeMap: Map[String, Int]): Vertex = {
     val index    = row.schema.fieldIndex(tagConfig.vertexField)
-    var vertexId = row.get(index).toString
+    var vertexId = row.get(index).toString.trim
     if (vertexId.equals(DEFAULT_EMPTY_VALUE)) {
       vertexId = ""
     }
@@ -250,7 +250,7 @@ class VerticesProcessor(spark: SparkSession,
     isVertexValid(row, tagConfig, false, vidType == VidType.STRING)
 
     val index: Int       = row.schema.fieldIndex(tagConfig.vertexField)
-    var vertexId: String = row.get(index).toString
+    var vertexId: String = row.get(index).toString.trim
     if (vertexId.equals(DEFAULT_EMPTY_VALUE)) {
       vertexId = ""
     }

--- a/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
+++ b/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/EdgeProcessor.scala
@@ -211,7 +211,7 @@ class EdgeProcessor(spark: SparkSession,
       if (index < 0 || row.isNullAt(index)) {
         printChoice(streamFlag, s"rank must exist and cannot be null, your row data is $row")
       }
-      val ranking = row.get(index).toString
+      val ranking = row.get(index).toString.trim
       if (!NebulaUtils.isNumic(ranking)) {
         printChoice(streamFlag,
                     s"Not support non-Numeric type for ranking field.your row data is $row")
@@ -239,7 +239,7 @@ class EdgeProcessor(spark: SparkSession,
       if (index < 0 || row.isNullAt(index)) {
         printChoice(streamFlag, s"$fieldType must exist and cannot be null, your row data is $row")
         None
-      } else Some(row.get(index).toString)
+      } else Some(row.get(index).toString.trim)
     }
 
     val idFlag = fieldValue.isDefined
@@ -285,7 +285,7 @@ class EdgeProcessor(spark: SparkSession,
 
     if (edgeConfig.rankingField.isDefined) {
       val index   = row.schema.fieldIndex(edgeConfig.rankingField.get)
-      val ranking = row.get(index).toString
+      val ranking = row.get(index).toString.trim
       Edge(sourceField, targetField, Some(ranking.toLong), values)
     } else {
       Edge(sourceField, targetField, None, values)
@@ -306,7 +306,7 @@ class EdgeProcessor(spark: SparkSession,
       indexCells(lat, lng).mkString(",")
     } else {
       val index = row.schema.fieldIndex(field)
-      val value = row.get(index).toString
+      val value = row.get(index).toString.trim
       if (value.equals(DEFAULT_EMPTY_VALUE)) "" else value
     }
     // process string type vid
@@ -328,13 +328,13 @@ class EdgeProcessor(spark: SparkSession,
     isEdgeValid(row, edgeConfig, false, vidType == VidType.STRING)
 
     val srcIndex: Int = row.schema.fieldIndex(edgeConfig.sourceField)
-    var srcId: String = row.get(srcIndex).toString
+    var srcId: String = row.get(srcIndex).toString.trim
     if (srcId.equals(DEFAULT_EMPTY_VALUE)) {
       srcId = ""
     }
 
     val dstIndex: Int = row.schema.fieldIndex(edgeConfig.targetField)
-    var dstId: String = row.get(dstIndex).toString
+    var dstId: String = row.get(dstIndex).toString.trim
     if (dstId.equals(DEFAULT_EMPTY_VALUE)) {
       dstId = ""
     }
@@ -366,7 +366,7 @@ class EdgeProcessor(spark: SparkSession,
 
     val ranking: Long = if (edgeConfig.rankingField.isDefined) {
       val rankIndex = row.schema.fieldIndex(edgeConfig.rankingField.get)
-      row.get(rankIndex).toString.toLong
+      row.get(rankIndex).toString.trim.toLong
     } else {
       0
     }

--- a/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
+++ b/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/processor/VerticesProcessor.scala
@@ -222,7 +222,7 @@ class VerticesProcessor(spark: SparkSession,
                       fieldKeys: List[String],
                       fieldTypeMap: Map[String, Int]): Vertex = {
     val index    = row.schema.fieldIndex(tagConfig.vertexField)
-    var vertexId = row.get(index).toString
+    var vertexId = row.get(index).toString.trim
     if (vertexId.equals(DEFAULT_EMPTY_VALUE)) {
       vertexId = ""
     }
@@ -250,7 +250,7 @@ class VerticesProcessor(spark: SparkSession,
     isVertexValid(row, tagConfig, false, vidType == VidType.STRING)
 
     val index: Int       = row.schema.fieldIndex(tagConfig.vertexField)
-    var vertexId: String = row.get(index).toString
+    var vertexId: String = row.get(index).toString.trim
     if (vertexId.equals(DEFAULT_EMPTY_VALUE)) {
       vertexId = ""
     }


### PR DESCRIPTION
For Postgresql datasource, if source value's data type is `CHAR(10)` but the value length is less than 10, then data read by spark will be fill with spaces.
Example: data in postgres is `"tom"` and it's data type is `CHAR(10)`, then after importing, the data in nebula will be `"tom       "`, which is wrong. So we need to remove the extra spaces.