### PR TITLE
V3.0.0 fix bug in kafka source

### DIFF
--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
@@ -345,9 +345,6 @@ object Configs {
     val tagConfigs = getConfigsOrNone(config, "tags")
     if (tagConfigs.isDefined) {
       for (tagConfig <- tagConfigs.get.asScala) {
-        if (hasKafka) {
-          throw new IllegalArgumentException("Can not define any other configs when kafka exists")
-        }
         if (!tagConfig.hasPath("name") ||
             !tagConfig.hasPath("type.source") ||
             !tagConfig.hasPath("type.sink")) {
@@ -381,6 +378,9 @@ object Configs {
         val sourceCategory = toSourceCategory(tagConfig.getString("type.source"))
         val sourceConfig   = dataSourceConfig(sourceCategory, tagConfig, nebulaConfig)
         LOG.info(s"Source Config ${sourceConfig}")
+        if (hasKafka && sourceCategory != SourceCategory.KAFKA) {
+          throw new IllegalArgumentException("Can not define any other configs when kafka exists")
+        }
         hasKafka = sourceCategory == SourceCategory.KAFKA
 
         val sinkCategory = toSinkCategory(tagConfig.getString("type.sink"))
@@ -419,9 +419,6 @@ object Configs {
     val edgeConfigs = getConfigsOrNone(config, "edges")
     if (edgeConfigs.isDefined) {
       for (edgeConfig <- edgeConfigs.get.asScala) {
-        if (hasKafka) {
-          throw new IllegalArgumentException("Can not define any other configs when kafka exists")
-        }
         if (!edgeConfig.hasPath("name") ||
             !edgeConfig.hasPath("type.source") ||
             !edgeConfig.hasPath("type.sink")) {
@@ -444,7 +441,9 @@ object Configs {
         val sourceCategory = toSourceCategory(edgeConfig.getString("type.source"))
         val sourceConfig   = dataSourceConfig(sourceCategory, edgeConfig, nebulaConfig)
         LOG.info(s"Source Config ${sourceConfig}")
-        hasKafka = sourceCategory == SourceCategory.KAFKA
+        if (hasKafka && sourceCategory != SourceCategory.KAFKA) {
+          throw new IllegalArgumentException("Can not define any other configs when kafka exists")
+        }
 
         val sinkCategory = toSinkCategory(edgeConfig.getString("type.sink"))
         val sinkConfig   = dataSinkConfig(sinkCategory, nebulaConfig)


### PR DESCRIPTION
当使用官网示例kafka source配置导入数据时会报如下错误![image](https://user-images.githubusercontent.com/50094541/168782387-a17ad521-d06d-4259-b468-20b34191b426.png)
查看源码
![image](https://user-images.githubusercontent.com/50094541/168782559-0cff7ff5-7e21-43c7-b4cc-146821e97c70.png)
![image](https://user-images.githubusercontent.com/50094541/168782626-6be0da1a-f5b4-4555-a8b8-32b7c4c117eb.png)
会在第一次循环将hasKafka置为true，那么下一次循环就一定会抛出异常
