### PR TITLE
hide the enableTagless config

### DIFF
--- a/nebula-exchange_spark_2.4/src/main/resources/application.conf
+++ b/nebula-exchange_spark_2.4/src/main/resources/application.conf
@@ -43,11 +43,6 @@
     pswd: nebula
     space: test
 
-    # enableTagless is used for sst mode.
-    # if false, just write vertex with tag to sst file
-    # if true, write vertex with tag and vertex without tag
-    enableTagless:false
-
     # if com.vesoft.exchange.common.config graph ssl encrypted transmission
     ssl:{
         # if enable is false, other params of ssl are invalid.


### PR DESCRIPTION
enableTagless is used for sst mode.
if false, just write vertex with tag to sst file
if true, write vertex with tag and vertex without tag
 
```
nebula: {
    address:{
      graph:["127.0.0.1:9669"]
      meta:["127.0.0.1:9559"]
    }
    user: root
    pswd: nebula
    space: test
    enableTagless:false
    ...
}
```