### PR TITLE
enhance the jdbc datasource to support multiple table query

### DIFF
--- a/exchange-common/pom.xml
+++ b/exchange-common/pom.xml
@@ -59,6 +59,12 @@
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.25</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
@@ -578,7 +578,7 @@ object Configs {
 
         val writeModeStr = getOrElse(edgeConfig, "writeMode", DEFAULT_WRITE_MODE)
         val writeMode    = toWriteModeCategory(writeModeStr)
-        val batch     = getOrElse(edgeConfig, "batch", DEFAULT_BATCH)
+        val batch        = getOrElse(edgeConfig, "batch", DEFAULT_BATCH)
         val checkPointPath =
           if (edgeConfig.hasPath("check_point_path")) Some(edgeConfig.getString("check_point_path"))
           else DEFAULT_CHECK_POINT_PATH
@@ -690,11 +690,11 @@ object Configs {
   }
 
   /**
-   * Use to get write mode according to category of writeMode.
-   *
-   * @param category
-   * @return
-   */
+    * Use to get write mode according to category of writeMode.
+    *
+    * @param category
+    * @return
+    */
   private[this] def toWriteModeCategory(category: String): WriteMode.Mode = {
     category.trim.toUpperCase match {
       case "INSERT" => WriteMode.INSERT
@@ -782,7 +782,7 @@ object Configs {
           config.getString("host"),
           config.getInt("port"),
           config.getString("database"),
-          config.getString("table"),
+          getOrElse(config, "table", null),
           config.getString("user"),
           config.getString("password"),
           getOrElse(config, "sentence", null)
@@ -793,7 +793,7 @@ object Configs {
           config.getString("host"),
           config.getInt("port"),
           config.getString("database"),
-          config.getString("table"),
+          getOrElse(config, "table", null),
           config.getString("user"),
           config.getString("password"),
           getOrElse(config, "sentence", null)
@@ -805,7 +805,7 @@ object Configs {
           config.getString("driver"),
           config.getString("user"),
           config.getString("password"),
-          config.getString("table"),
+          getOrElse(config, "table", null),
           getOrElse(config, "sentence", null)
         )
       case SourceCategory.JDBC =>
@@ -840,7 +840,7 @@ object Configs {
           config.getString("driver"),
           config.getString("user"),
           config.getString("password"),
-          config.getString("table"),
+          getOrElse(config, "table", null),
           partitionColumn,
           lowerBound,
           upperBound,
@@ -896,28 +896,16 @@ object Configs {
                                config.getString("columnFamily"),
                                fields.toSet.toList)
       case SourceCategory.MAXCOMPUTE => {
-        val partitionSpec = if (config.hasPath("partitionSpec")) {
-          config.getString("partitionSpec")
-        } else {
-          null
-        }
-        val numPartitions = if (config.hasPath("numPartitions")) {
-          config.getString("numPartitions")
-        } else {
-          "1"
-        }
-
-        val sentence = if (config.hasPath("sentence")) {
-          config.getString("sentence")
-        } else {
-          null
-        }
+        val table         = getOrElse(config, "table", null)
+        val partitionSpec = getOrElse(config, "partitionSpec", null)
+        val numPartitions = getOrElse(config, "numPartitions", "1")
+        val sentence      = getOrElse(config, "sentence", null)
 
         MaxComputeConfigEntry(
           SourceCategory.MAXCOMPUTE,
           config.getString("odpsUrl"),
           config.getString("tunnelUrl"),
-          config.getString("table"),
+          table,
           config.getString("project"),
           config.getString("accessKeyId"),
           config.getString("accessKeySecret"),
@@ -927,19 +915,15 @@ object Configs {
         )
       }
       case SourceCategory.CLICKHOUSE => {
-        val partition: String = if (config.hasPath("numPartition")) {
-          config.getString("numPartition")
-        } else {
-          "1"
-        }
+        val partition: String = getOrElse (config, "numPartition", "1")
         ClickHouseConfigEntry(
           SourceCategory.CLICKHOUSE,
           config.getString("url"),
           config.getString("user"),
           config.getString("password"),
           partition,
-          config.getString("table"),
-          config.getString("sentence")
+          getOrElse(config, "table", null),
+          getOrElse(config, "sentence", null)
         )
       }
       case _ =>

--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SourceConfigs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SourceConfigs.scala
@@ -6,6 +6,7 @@
 package com.vesoft.exchange.common.config
 
 import com.vesoft.exchange.common.utils.NebulaUtils
+import org.apache.spark.sql.SparkSession
 
 /**
   * Category use to explain the data source which the Spark application could reading.
@@ -152,7 +153,11 @@ case class MySQLSourceConfigEntry(override val category: SourceCategory.Value,
                                   override val sentence: String)
     extends ServerDataSourceConfigEntry {
   require(
-    host.trim.length != 0 && port > 0 && database.trim.length > 0 && table.trim.length > 0 && user.trim.length > 0)
+    host != null && database != null & user != null && password != null &&
+      host.trim.nonEmpty && port > 0 && database.trim.nonEmpty && user.trim.nonEmpty)
+  require(table == null || sentence == null,
+          "table and sentence cannot be config at the same time for MYSQL.")
+  require(table != null || sentence != null, "Either table or sentence must be config for MYSQL.")
 
   override def toString: String = {
     s"MySql source host: ${host}, port: ${port}, database: ${database}, table: ${table}, " +
@@ -182,7 +187,12 @@ case class PostgreSQLSourceConfigEntry(override val category: SourceCategory.Val
                                        override val sentence: String)
     extends ServerDataSourceConfigEntry {
   require(
-    host.trim.length != 0 && port > 0 && database.trim.length > 0 && table.trim.length > 0 && user.trim.length > 0)
+    host != null && database != null & user != null && password != null &&
+      host.trim.nonEmpty && port > 0 && database.trim.nonEmpty && user.trim.nonEmpty)
+  require(table == null || sentence == null,
+          "table and sentence cannot be config at the same time for PostgreSQL.")
+  require(table != null || sentence != null,
+          "Either table or sentence must be config for PostgreSQL.")
 
   override def toString: String = {
     s"PostgreSql source host: ${host}, port: ${port}, database: ${database}, table: ${table}, " +
@@ -246,8 +256,8 @@ case class HBaseSourceConfigEntry(override val category: SourceCategory.Value,
                                   fields: List[String])
     extends ServerDataSourceConfigEntry() {
 
-  require(host.trim.length != 0 && port.trim.length != 0 && NebulaUtils
-    .isNumic(port.trim) && table.trim.length > 0 && table.trim.length > 0 && columnFamily.trim.length > 0)
+  require(host.trim.nonEmpty && port.trim.nonEmpty && NebulaUtils
+    .isNumic(port.trim) && table.trim.nonEmpty && table.trim.nonEmpty && columnFamily.trim.nonEmpty)
 
   override val sentence: String = null
 
@@ -271,8 +281,10 @@ case class MaxComputeConfigEntry(override val category: SourceCategory.Value,
                                  override val sentence: String)
     extends ServerDataSourceConfigEntry {
   require(
-    !odpsUrl.trim.isEmpty && !tunnelUrl.trim.isEmpty && !table.trim.isEmpty && !project.trim.isEmpty
-      && !accessKeyId.trim.isEmpty && !accessKeySecret.trim.isEmpty)
+    odpsUrl != null & tunnelUrl != null && project != null && accessKeyId != null
+      && accessKeySecret != null && odpsUrl.trim.nonEmpty && tunnelUrl.trim.nonEmpty
+      && table.trim.nonEmpty && project.trim.nonEmpty
+      && accessKeyId.trim.nonEmpty && accessKeySecret.trim.nonEmpty)
 
   override def toString: String = {
     s"MaxCompute source {odpsUrl: $odpsUrl, tunnelUrl: $tunnelUrl, table: $table, project: $project, " +
@@ -293,6 +305,8 @@ case class ClickHouseConfigEntry(override val category: SourceCategory.Value,
                                  table: String,
                                  override val sentence: String)
     extends ServerDataSourceConfigEntry {
+  require(url != null && user != null && passwd != null)
+  require(sentence != null, "sentence for ClickHouse cannot be null for ClickHouse.")
   override def toString: String = {
     s"ClickHouse source {url:$url, user:$user, passwd:$passwd, numPartition:$numPartition, table:$table, sentence:$sentence}"
   }
@@ -309,6 +323,11 @@ case class OracleConfigEntry(override val category: SourceCategory.Value,
                              table: String,
                              override val sentence: String)
     extends ServerDataSourceConfigEntry {
+  require(url != null && driver != null && user != null && passwd != null)
+  require(table == null || sentence == null,
+          "table and sentence cannot be config at the same time for Oracle.")
+  require(table != null || sentence != null, "Either table or sentence must be config for Oracle.")
+
   override def toString: String = {
     s"Oracle source {url:$url, driver:$driver, user:$user, passwd:$passwd, table:$table, sentence:$sentence}"
   }
@@ -340,6 +359,8 @@ case class JdbcConfigEntry(override val category: SourceCategory.Value,
                            fetchSize: Option[Long] = None,
                            override val sentence: String)
     extends ServerDataSourceConfigEntry {
+  require(url != null && driver != null && user != null && passwd != null)
+  require(table != null || sentence != null, "Either table or sentence must be config for JDBC.")
   override def toString: String = {
     s"Jdbc source {url:$url, driver:$driver, user:$user, passwd:$passwd, table:$table, sentence:$sentence}"
   }

--- a/exchange-common/src/test/resources/application.conf
+++ b/exchange-common/src/test/resources/application.conf
@@ -266,7 +266,7 @@
       table:table
       user:root
       password:nebula
-      sentence: "select mysql-field0, mysql-field1, mysql-field2 from database.table"
+      # sentence: "select mysql-field0, mysql-field1, mysql-field2 from database.table"
       fields: [mysql-field-0, mysql-field-1, mysql-field-2]
       nebula.fields: [nebula-field-0, nebula-field-1, nebula-field-2]
       vertex: {
@@ -292,7 +292,7 @@
       table: table
       user: root
       password: nebula
-      sentence: "select postgre-field0, postgre-field1, postgre-field2 from table"
+      # sentence: "select postgre-field0, postgre-field1, postgre-field2 from table"
       fields: [postgre-field-0, postgre-field-1, postgre-field-2]
       nebula.fields: [nebula-field-0, nebula-field-1, nebula-field-2]
       vertex: {

--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
@@ -146,6 +146,9 @@ object Exchange {
 
         val fields = tagConfig.vertexField :: tagConfig.fields
         val data   = createDataSource(spark, tagConfig.dataSourceConfigEntry, fields)
+        if (data.isDefined && c.dry && !data.get.isStreaming) {
+          data.get.show(truncate = false)
+        }
         if (data.isDefined && !c.dry) {
           val df = if (tagConfig.vertexUdf.isDefined) {
             dataUdf(data.get, tagConfig.vertexUdf.get)
@@ -200,6 +203,9 @@ object Exchange {
           edgeConfig.sourceField :: edgeConfig.targetField :: edgeConfig.fields
         }
         val data = createDataSource(spark, edgeConfig.dataSourceConfigEntry, fields)
+        if (data.isDefined && c.dry && !data.get.isStreaming) {
+          data.get.show(truncate = false)
+        }
         if (data.isDefined && !c.dry) {
           var df = data.get
           if (edgeConfig.srcVertexUdf.isDefined) {

--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/reader/ServerBaseReader.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/reader/ServerBaseReader.scala
@@ -82,22 +82,22 @@ class HiveReader(override val session: SparkSession, hiveConfig: HiveSourceConfi
   */
 class MySQLReader(override val session: SparkSession, mysqlConfig: MySQLSourceConfigEntry)
     extends ServerBaseReader(session, mysqlConfig.sentence) {
+  Class.forName("com.mysql.cj.jdbc.Driver")
   override def read(): DataFrame = {
     val url =
       s"jdbc:mysql://${mysqlConfig.host}:${mysqlConfig.port}/${mysqlConfig.database}?useUnicode=true&characterEncoding=utf-8"
-    val df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("url", url)
-      .option("dbtable", mysqlConfig.table)
       .option("user", mysqlConfig.user)
       .option("password", mysqlConfig.password)
-      .load()
-    if (sentence != null) {
-      df.createOrReplaceTempView(mysqlConfig.table)
-      session.sql(sentence)
-    } else {
-      df
+    if (mysqlConfig.table != null) {
+      dfReader.option("dbtable", mysqlConfig.table)
     }
+    if (sentence != null) {
+      dfReader.option("query", mysqlConfig.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -110,23 +110,24 @@ class MySQLReader(override val session: SparkSession, mysqlConfig: MySQLSourceCo
 class PostgreSQLReader(override val session: SparkSession,
                        postgreConfig: PostgreSQLSourceConfigEntry)
     extends ServerBaseReader(session, postgreConfig.sentence) {
+  Class.forName("org.postgresql.Driver")
   override def read(): DataFrame = {
     val url =
       s"jdbc:postgresql://${postgreConfig.host}:${postgreConfig.port}/${postgreConfig.database}"
-    val df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("driver", "org.postgresql.Driver")
       .option("url", url)
-      .option("dbtable", postgreConfig.table)
       .option("user", postgreConfig.user)
       .option("password", postgreConfig.password)
-      .load()
-    if (sentence != null) {
-      df.createOrReplaceTempView(postgreConfig.table)
-      session.sql(sentence)
-    } else {
-      df
+
+    if (postgreConfig.table != null) {
+      dfReader.option("dbtable", postgreConfig.table)
     }
+    if (postgreConfig.sentence != null) {
+      dfReader.option("query", postgreConfig.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -278,17 +279,21 @@ class ClickhouseReader(override val session: SparkSession,
     extends ServerBaseReader(session, clickHouseConfigEntry.sentence) {
   Class.forName("ru.yandex.clickhouse.ClickHouseDriver")
   override def read(): DataFrame = {
-    val df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("driver", "ru.yandex.clickhouse.ClickHouseDriver")
       .option("url", clickHouseConfigEntry.url)
       .option("user", clickHouseConfigEntry.user)
       .option("password", clickHouseConfigEntry.passwd)
       .option("numPartitions", clickHouseConfigEntry.numPartition)
-      .option("dbtable", clickHouseConfigEntry.table)
-      .option("query", clickHouseConfigEntry.sentence)
-      .load()
-    df
+
+    if (clickHouseConfigEntry.table != null) {
+      dfReader.option("dbtable", clickHouseConfigEntry.table)
+    }
+    if (clickHouseConfigEntry.sentence != null) {
+      dfReader.option("query", clickHouseConfigEntry.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -298,24 +303,21 @@ class ClickhouseReader(override val session: SparkSession,
 class OracleReader(override val session: SparkSession, oracleConfig: OracleConfigEntry)
     extends ServerBaseReader(session, oracleConfig.sentence) {
   Class.forName(oracleConfig.driver)
+
   override def read(): DataFrame = {
-    var df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("url", oracleConfig.url)
-      .option("dbtable", oracleConfig.table)
       .option("user", oracleConfig.user)
       .option("password", oracleConfig.passwd)
       .option("driver", oracleConfig.driver)
-      .load()
-
-    if (oracleConfig.sentence != null) {
-      val tableName = if (oracleConfig.table.contains(".")) {
-        oracleConfig.table.split("\\.")(1)
-      } else oracleConfig.table
-      df.createOrReplaceTempView(tableName)
-      df = session.sql(sentence)
+    if (oracleConfig.table != null) {
+      dfReader.option("table", oracleConfig.table)
     }
-    df
+    if (oracleConfig.sentence != null) {
+      dfReader.option("query", oracleConfig.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -337,14 +339,16 @@ class JdbcReader(override val session: SparkSession, jdbcConfig: JdbcConfigEntry
     }
     JdbcDialects.registerDialect(GoogleDialect)
 
-    var dfReader = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("url", jdbcConfig.url)
-      .option("dbtable", jdbcConfig.table)
       .option("user", jdbcConfig.user)
       .option("password", jdbcConfig.passwd)
       .option("driver", jdbcConfig.driver)
 
+    if (jdbcConfig.table != null) {
+      dfReader.option("dbtable", jdbcConfig.table)
+    }
     if (jdbcConfig.partitionColumn.isDefined) {
       dfReader.option("partitionColumn", jdbcConfig.partitionColumn.get)
     }
@@ -360,13 +364,10 @@ class JdbcReader(override val session: SparkSession, jdbcConfig: JdbcConfigEntry
     if (jdbcConfig.fetchSize.isDefined) {
       dfReader.option("fetchsize", jdbcConfig.fetchSize.get)
     }
-
     var df = dfReader.load()
-
     if (jdbcConfig.sentence != null) {
-      val tableName = if (jdbcConfig.table.contains(".")) {
-        jdbcConfig.table.split("\\.")(1)
-      } else jdbcConfig.table
+      val tableName =
+        if (jdbcConfig.table.contains(".")) jdbcConfig.table.split("\\.")(1) else jdbcConfig.table
       df.createOrReplaceTempView(tableName)
       df = session.sql(sentence)
     }

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
@@ -146,6 +146,9 @@ object Exchange {
 
         val fields = tagConfig.vertexField :: tagConfig.fields
         val data   = createDataSource(spark, tagConfig.dataSourceConfigEntry, fields)
+        if (data.isDefined && c.dry && !data.get.isStreaming) {
+          data.get.show(truncate = false)
+        }
         if (data.isDefined && !c.dry) {
           val df = if (tagConfig.vertexUdf.isDefined) {
             dataUdf(data.get, tagConfig.vertexUdf.get)
@@ -200,6 +203,9 @@ object Exchange {
           edgeConfig.sourceField :: edgeConfig.targetField :: edgeConfig.fields
         }
         val data = createDataSource(spark, edgeConfig.dataSourceConfigEntry, fields)
+        if (data.isDefined && c.dry && !data.get.isStreaming) {
+          data.get.show(truncate = false)
+        }
         if (data.isDefined && !c.dry) {
           var df = data.get
           if (edgeConfig.srcVertexUdf.isDefined) {

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/reader/ServerBaseReader.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/reader/ServerBaseReader.scala
@@ -87,19 +87,18 @@ class MySQLReader(override val session: SparkSession, mysqlConfig: MySQLSourceCo
   override def read(): DataFrame = {
     val url =
       s"jdbc:mysql://${mysqlConfig.host}:${mysqlConfig.port}/${mysqlConfig.database}?useUnicode=true&characterEncoding=utf-8"
-    val df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("url", url)
-      .option("dbtable", mysqlConfig.table)
       .option("user", mysqlConfig.user)
       .option("password", mysqlConfig.password)
-      .load()
-    if (sentence != null) {
-      df.createOrReplaceTempView(mysqlConfig.table)
-      session.sql(sentence)
-    } else {
-      df
+    if (mysqlConfig.table != null) {
+      dfReader.option("dbtable", mysqlConfig.table)
     }
+    if (sentence != null) {
+      dfReader.option("query", mysqlConfig.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -112,20 +111,20 @@ class PostgreSQLReader(override val session: SparkSession,
   override def read(): DataFrame = {
     val url =
       s"jdbc:postgresql://${postgreConfig.host}:${postgreConfig.port}/${postgreConfig.database}"
-    val df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("driver", "org.postgresql.Driver")
       .option("url", url)
-      .option("dbtable", postgreConfig.table)
       .option("user", postgreConfig.user)
       .option("password", postgreConfig.password)
-      .load()
-    if (sentence != null) {
-      df.createOrReplaceTempView(postgreConfig.table)
-      session.sql(sentence)
-    } else {
-      df
+
+    if (postgreConfig.table != null) {
+      dfReader.option("dbtable", postgreConfig.table)
     }
+    if (postgreConfig.sentence != null) {
+      dfReader.option("query", postgreConfig.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -337,16 +336,21 @@ class ClickhouseReader(override val session: SparkSession,
   Class.forName("ru.yandex.clickhouse.ClickHouseDriver")
 
   override def read(): DataFrame = {
-    val df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("driver", "ru.yandex.clickhouse.ClickHouseDriver")
       .option("url", clickHouseConfigEntry.url)
       .option("user", clickHouseConfigEntry.user)
       .option("password", clickHouseConfigEntry.passwd)
       .option("numPartitions", clickHouseConfigEntry.numPartition)
-      .option("query", clickHouseConfigEntry.sentence)
-      .load()
-    df
+
+    if (clickHouseConfigEntry.table != null) {
+      dfReader.option("dbtable", clickHouseConfigEntry.table)
+    }
+    if (clickHouseConfigEntry.sentence != null) {
+      dfReader.option("query", clickHouseConfigEntry.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -357,23 +361,19 @@ class OracleReader(override val session: SparkSession, oracleConfig: OracleConfi
     extends ServerBaseReader(session, oracleConfig.sentence) {
   Class.forName(oracleConfig.driver)
   override def read(): DataFrame = {
-    var df = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("url", oracleConfig.url)
-      .option("dbtable", oracleConfig.table)
       .option("user", oracleConfig.user)
       .option("password", oracleConfig.passwd)
       .option("driver", oracleConfig.driver)
-      .load()
-
-    if (oracleConfig.sentence != null) {
-      val tableName = if (oracleConfig.table.contains(".")) {
-        oracleConfig.table.split("\\.")(1)
-      } else oracleConfig.table
-      df.createOrReplaceTempView(tableName)
-      df = session.sql(sentence)
+    if (oracleConfig.table != null) {
+      dfReader.option("table", oracleConfig.table)
     }
-    df
+    if (oracleConfig.sentence != null) {
+      dfReader.option("query", oracleConfig.sentence)
+    }
+    dfReader.load()
   }
 }
 
@@ -384,6 +384,9 @@ class JdbcReader(override val session: SparkSession, jdbcConfig: JdbcConfigEntry
     extends ServerBaseReader(session, jdbcConfig.sentence) {
   Class.forName(jdbcConfig.driver)
   override def read(): DataFrame = {
+    require(jdbcConfig.table == null || jdbcConfig.sentence == null,
+            "table and sentence cannot config at the same time for JDBC.")
+
     import org.apache.spark.sql.jdbc.{JdbcDialects, JdbcDialect}
     val GoogleDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean =
@@ -395,14 +398,16 @@ class JdbcReader(override val session: SparkSession, jdbcConfig: JdbcConfigEntry
     }
     JdbcDialects.registerDialect(GoogleDialect)
 
-    var dfReader = session.read
+    val dfReader = session.read
       .format("jdbc")
       .option("url", jdbcConfig.url)
-      .option("dbtable", jdbcConfig.table)
       .option("user", jdbcConfig.user)
       .option("password", jdbcConfig.passwd)
       .option("driver", jdbcConfig.driver)
 
+    if (jdbcConfig.table != null) {
+      dfReader.option("dbtable", jdbcConfig.table)
+    }
     if (jdbcConfig.partitionColumn.isDefined) {
       dfReader.option("partitionColumn", jdbcConfig.partitionColumn.get)
     }
@@ -418,16 +423,9 @@ class JdbcReader(override val session: SparkSession, jdbcConfig: JdbcConfigEntry
     if (jdbcConfig.fetchSize.isDefined) {
       dfReader.option("fetchsize", jdbcConfig.fetchSize.get)
     }
-
-    var df = dfReader.load()
-
     if (jdbcConfig.sentence != null) {
-      val tableName = if (jdbcConfig.table.contains(".")) {
-        jdbcConfig.table.split("\\.")(1)
-      } else jdbcConfig.table
-      df.createOrReplaceTempView(tableName)
-      df = session.sql(sentence)
+      dfReader.option("query", jdbcConfig.sentence)
     }
-    df
+    dfReader.load()
   }
 }

--- a/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
+++ b/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/Exchange.scala
@@ -146,6 +146,9 @@ object Exchange {
 
         val fields = tagConfig.vertexField :: tagConfig.fields
         val data   = createDataSource(spark, tagConfig.dataSourceConfigEntry, fields)
+        if (data.isDefined && c.dry && !data.get.isStreaming) {
+          data.get.show(truncate = false)
+        }
         if (data.isDefined && !c.dry) {
           val df = if (tagConfig.vertexUdf.isDefined) {
             dataUdf(data.get, tagConfig.vertexUdf.get)
@@ -200,6 +203,9 @@ object Exchange {
           edgeConfig.sourceField :: edgeConfig.targetField :: edgeConfig.fields
         }
         val data = createDataSource(spark, edgeConfig.dataSourceConfigEntry, fields)
+        if (data.isDefined && c.dry && !data.get.isStreaming) {
+          data.get.show(truncate = false)
+        }
         if (data.isDefined && !c.dry) {
           var df = data.get
           if (edgeConfig.srcVertexUdf.isDefined) {


### PR DESCRIPTION
Enhance the data reading capabilities of relational databases：
1. support single-table scanning, and also support multi-table queries. 
2. For nebula-exchange_spark_2.2, since the jdbc datasource only allows reading of a single table, and does not allow querying from the database, we support to query the single table in SparkSQL and still does not support multiple tables query.

for nebula-exchange_spark_2.2, the jdbc config should be:
```
      url:"jdbc:mysql://127.0.0.1:3306/test"
      driver: "com.mysql.cj.jdbc.Driver"
      user: "nebula"
      password: "Nebula@123"
      table: "test.people"
      sentence: "select * from  people" #sentence config is optional. the table name in sentence must just be table, not db.name
```
the mysql/oracle/postgresql config shoud just config table, do not support sentence.

for nebula-exchange_spark_2.4 or 3.0, the jdbc config should be:
```
      url:"jdbc:mysql://127.0.0.1:3306/test"
      driver: "com.mysql.cj.jdbc.Driver"
      user: "nebula"
      password: "Nebula@123"
      table: "test.people"
      # sentence and table cannot config together.
      # sentence: "select * from  people, player, team"
```
the same for mysql/oracle/postgresql as jdbc.