### PR TITLE
support kafka with security certification

### DIFF
--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SourceConfigs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/SourceConfigs.scala
@@ -213,9 +213,17 @@ case class KafkaSourceConfigEntry(override val category: SourceCategory.Value,
                                   server: String,
                                   topic: String,
                                   startingOffsets: String,
-                                  maxOffsetsPerTrigger: Option[Long] = None)
+                                  maxOffsetsPerTrigger: Option[Long] = None,
+                                  securityProtocol: Option[String] = None,
+                                  mechanism: Option[String] = None,
+                                  kerberos: Boolean = false,
+                                  kerberosServiceName: String = null)
     extends StreamingDataSourceConfigEntry {
-  require(server.trim.nonEmpty && topic.trim.nonEmpty)
+  require(server.trim.nonEmpty && topic.trim.nonEmpty, "server or topic cannot be empty")
+  require(securityProtocol.isEmpty || mechanism.isDefined,
+          "security protocol is defined, mechanism must be config.")
+  require(!kerberos || kerberosServiceName.nonEmpty,
+          "kerberos is true, service name must be config")
 
   override def toString: String = {
     s"Kafka source server: ${server} topic:${topic} startingOffsets:${startingOffsets} maxOffsetsPerTrigger:${maxOffsetsPerTrigger}"

--- a/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/reader/StreamingBaseReader.scala
+++ b/nebula-exchange_spark_2.2/src/main/scala/com/vesoft/nebula/exchange/reader/StreamingBaseReader.scala
@@ -46,6 +46,14 @@ class KafkaReader(override val session: SparkSession,
         .option("subscribe", kafkaConfig.topic)
         .option("startingOffsets", kafkaConfig.startingOffsets)
 
+    if (kafkaConfig.securityProtocol.isDefined) {
+      reader.option("kafka.security.protocol", kafkaConfig.securityProtocol.get)
+      reader.option("kafka.sasl.mechanism", kafkaConfig.mechanism.get)
+    }
+    if (kafkaConfig.kerberos) {
+      reader.option("kafka.sasl.kerberos.service.name", kafkaConfig.kerberosServiceName)
+    }
+
     val maxOffsetsPerTrigger = kafkaConfig.maxOffsetsPerTrigger
     if (maxOffsetsPerTrigger.isDefined)
       reader.option("maxOffsetsPerTrigger", maxOffsetsPerTrigger.get)

--- a/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/reader/StreamingBaseReader.scala
+++ b/nebula-exchange_spark_2.4/src/main/scala/com/vesoft/nebula/exchange/reader/StreamingBaseReader.scala
@@ -9,6 +9,8 @@ import com.vesoft.exchange.common.config.{KafkaSourceConfigEntry, PulsarSourceCo
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+import scala.collection.mutable
+
 /**
   * Spark Streaming
   *
@@ -46,6 +48,13 @@ class KafkaReader(override val session: SparkSession,
         .option("subscribe", kafkaConfig.topic)
         .option("startingOffsets", kafkaConfig.startingOffsets)
 
+    if(kafkaConfig.securityProtocol.isDefined){
+      reader.option("kafka.security.protocol", kafkaConfig.securityProtocol.get)
+      reader.option("kafka.sasl.mechanism", kafkaConfig.mechanism.get)
+    }
+    if(kafkaConfig.kerberos){
+      reader.option("kafka.sasl.kerberos.service.name", kafkaConfig.kerberosServiceName)
+    }
     val maxOffsetsPerTrigger = kafkaConfig.maxOffsetsPerTrigger
     if (maxOffsetsPerTrigger.isDefined)
       reader.option("maxOffsetsPerTrigger", maxOffsetsPerTrigger.get)

--- a/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/reader/StreamingBaseReader.scala
+++ b/nebula-exchange_spark_3.0/src/main/scala/com/vesoft/nebula/exchange/reader/StreamingBaseReader.scala
@@ -46,6 +46,14 @@ class KafkaReader(override val session: SparkSession,
         .option("subscribe", kafkaConfig.topic)
         .option("startingOffsets", kafkaConfig.startingOffsets)
 
+    if (kafkaConfig.securityProtocol.isDefined) {
+      reader.option("kafka.security.protocol", kafkaConfig.securityProtocol.get)
+      reader.option("kafka.sasl.mechanism", kafkaConfig.mechanism.get)
+    }
+    if (kafkaConfig.kerberos) {
+      reader.option("kafka.sasl.kerberos.service.name", kafkaConfig.kerberosServiceName)
+    }
+
     val maxOffsetsPerTrigger = kafkaConfig.maxOffsetsPerTrigger
     if (maxOffsetsPerTrigger.isDefined)
       reader.option("maxOffsetsPerTrigger", maxOffsetsPerTrigger.get)


### PR DESCRIPTION
close https://github.com/vesoft-inc/nebula-exchange/issues/185

support kerberos, SASL, SASL_PLAINTEXT.

# How to use:

* if the kafka is not security certificated, then just config the following common configs:

    ```
      service:"127.0.0.1:9092"
      topic:"test"
      interval.seconds:10
      startingOffsets:earliest
      maxOffsetsPerTrigger:0
    ```

* if the kafka is security certificated by Kerberos, then add the following configs on the base of common configs:

      
      securityProtocol:SASL_PLAINTEXT
      mechanism:GASSAPI
      kerberos:true
      kerberosServiceName:kafka
      

When submit the exchange to spark, we need to config the `kafka_client_jaas.conf` and the `krb5.conf` for driver and executor :


    spark-submit --master xxx \
     --conf "spark.driver.extraJavaOptions=-Djava.security.auth.login.config=/path/kafka_client_jaas.conf -Djava.security.krb5.conf=/path/krb5.conf" \
    --conf "spark.executor.extraJavaOptions=-Djava.security.auth.login.config=path//kafka_client_jaas.conf -Djava.security.krb5.conf=path/krb5.conf" \
    --files /local/path/to/kafka_client_jaas.conf,/local/path/to/kafka.keytab,/local/path/to/krb5.conf \
    --class  com.vesoft.nebula.exchange.Exchange  \
    nebula-exchange-2.4-3.0-SNAPSHOT.jar -c application.conf
 


* if the kafka is security certificated by other security protocol, then just add the following configs on the base of common configs:

      securityProtocol:SASL_PLAINTEXT
      mechanism:GASSAPI


When submit the exchange to spark, we need to config the `kafka_client_jaas.conf` and the `krb5.conf` for driver and executor :

```
 spark-submit --master xxx \
 --conf "spark.driver.extraJavaOptions=-Djava.security.auth.login.config=/path/kafka_client_jaas.conf" \
 --conf "spark.executor.extraJavaOptions=-Djava.security.auth.login.config=path//kafka_client_jaas.conf" \
 --files /local/path/to/kafka_client_jaas.conf \
 --class  com.vesoft.nebula.exchange.Exchange  \
 nebula-exchange-2.4-3.0-SNAPSHOT.jar -c application.conf
```

