### PR TITLE
fix hdfs append bug

### DIFF
--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/ErrorHandler.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/ErrorHandler.scala
@@ -9,6 +9,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.log4j.Logger
 
+import java.util.UUID
 import scala.collection.mutable.ArrayBuffer
 
 object ErrorHandler {
@@ -16,13 +17,13 @@ object ErrorHandler {
   private[this] val LOG = Logger.getLogger(this.getClass)
 
   /**
-    * clean all the failed data for error path before reload.
-    *
-    * @param path path to clean
-    */
+   * clean all the failed data for error path before reload.
+   *
+   * @param path path to clean
+   */
   def clear(path: String): Unit = {
     try {
-      val fileSystem  = FileSystem.get(new Configuration())
+      val fileSystem = FileSystem.get(new Configuration())
       val filesStatus = fileSystem.listStatus(new Path(path))
       for (file <- filesStatus) {
         if (!file.getPath.getName.startsWith("reload.")) {
@@ -32,27 +33,28 @@ object ErrorHandler {
     } catch {
       case e: Throwable => {
         LOG.error(s"$path cannot be clean, but this error does not affect the import result, " +
-                    s"you can only focus on the reload files.",
-                  e)
+          s"you can only focus on the reload files.",
+          e)
       }
     }
   }
 
   /**
-    * save the failed execute statement.
-    *
-    * @param buffer buffer saved failed ngql
-    * @param path path to write these buffer ngql
-    */
+   * save the failed execute statement.
+   *
+   * @param buffer buffer saved failed ngql
+   * @param path   path to write these buffer ngql
+   */
   def save(buffer: ArrayBuffer[String], path: String): Unit = {
-    LOG.info(s"create reload path $path")
-
     val targetPath = new Path(path)
     val fileSystem = targetPath.getFileSystem(new Configuration())
     val errors = if (fileSystem.exists(targetPath)) {
+      val newPath = s"${path}_append_${UUID.randomUUID().toString}"
+      LOG.info(s"create reload path $newPath")
       // For kafka, the error ngql need to append to a same file instead of overwrite
-      fileSystem.append(targetPath)
+      fileSystem.create(new Path(newPath))
     } else {
+      LOG.info(s"create reload path $path")
       fileSystem.create(targetPath)
     }
 
@@ -67,13 +69,13 @@ object ErrorHandler {
   }
 
   /**
-    * check if path exists
-    *
-    * @param path error path
-    *@return true if path exists
-    */
+   * check if path exists
+   *
+   * @param path error path
+   * @return true if path exists
+   */
   def existError(path: String): Boolean = {
-    val errorPath  = new Path(path)
+    val errorPath = new Path(path)
     val fileSystem = errorPath.getFileSystem(new Configuration())
     fileSystem.exists(new Path(path))
   }


### PR DESCRIPTION
close https://github.com/vesoft-inc/nebula-exchange/issues/196

when spark submit master is local, and when there are several tag/edge configurations with the same name in the configuration file, and the error output path is configured with a local address but not a hdfs address, the file path to save write failed data will be the same, `append` operation will happen.
And when hdfs does not support append mode, it will cause exception in #196 .

In this pr, remove the append mode, and add uuid for path to make sure the paths to save write failed data are not the same.