### PR TITLE
add - add upsert

### DIFF
--- a/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
+++ b/exchange-common/src/main/scala/com/vesoft/exchange/common/config/Configs.scala
@@ -43,6 +43,7 @@ object WriteMode extends Enumeration {
   val INSERT = Value("insert")
   val UPDATE = Value("update")
   val DELETE = Value("delete")
+  val UPSERT = Value("upsert")
 }
 
 /**
@@ -721,6 +722,7 @@ object Configs {
       case "INSERT" => WriteMode.INSERT
       case "UPDATE" => WriteMode.UPDATE
       case "DELETE" => WriteMode.DELETE
+      case "UPSERT" => WriteMode.UPSERT
       case _        => throw new IllegalArgumentException(s"${category} not support")
     }
   }

--- a/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/ServerBaseWriterSuite.scala
+++ b/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/ServerBaseWriterSuite.scala
@@ -227,6 +227,7 @@ class ServerBaseWriterSuite extends ServerBaseWriter {
         "`col_string`=\"name2\",`col_fixed_string`=\"name2\",`col_bool`=false,`col_int`=11," +
         "`col_int64`=101,`col_double`=2.0,`col_date`=2021-11-13," +
         "`col_geo`=POLYGON((0 1, 1 2, 2 3, 0 1))"
+    println(sentence)
     assert(expectSentence.equals(sentence))
   }
 

--- a/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/ServerBaseWriterSuite.scala
+++ b/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/ServerBaseWriterSuite.scala
@@ -192,6 +192,43 @@ class ServerBaseWriterSuite extends ServerBaseWriter {
     assert(sentence.equals(expectSentence))
   }
 
+  @Test
+  def toUpsertExecuteSentenceSuiteForVertex():Unit = {
+    val vertices: ListBuffer[Vertex] = new ListBuffer[Vertex]
+    val propNames = List("col_string",
+      "col_fixed_string",
+      "col_bool",
+      "col_int",
+      "col_int64",
+      "col_double",
+      "col_date",
+      "col_geo")
+
+    val props1 =
+      List("\"name\"", "\"name\"", true, 10, 100L, 1.0, "2021-11-12", "LINESTRING(1 2, 3 4)")
+    val props2 = List("\"name2\"",
+      "\"name2\"",
+      false,
+      11,
+      101L,
+      2.0,
+      "2021-11-13",
+      "POLYGON((0 1, 1 2, 2 3, 0 1))")
+
+    vertices.append(Vertex("\"vid1\"", props1))
+    vertices.append(Vertex("\"vid2\"", props2))
+    val nebulaVertices = Vertices(propNames, vertices.toList, None)
+
+    val sentence = toUpsertExecuteSentence("person", nebulaVertices)
+    val expectSentence =
+      "UPSERT VERTEX ON `person` \"vid1\" SET `col_string`=\"name\",`col_fixed_string`=\"name\"," +
+        "`col_bool`=true,`col_int`=10,`col_int64`=100,`col_double`=1.0,`col_date`=2021-11-12," +
+        "`col_geo`=LINESTRING(1 2, 3 4);UPSERT VERTEX ON `person` \"vid2\" SET " +
+        "`col_string`=\"name2\",`col_fixed_string`=\"name2\",`col_bool`=false,`col_int`=11," +
+        "`col_int64`=101,`col_double`=2.0,`col_date`=2021-11-13," +
+        "`col_geo`=POLYGON((0 1, 1 2, 2 3, 0 1))"
+    assert(expectSentence.equals(sentence))
+  }
 
   override def writeVertices(vertices: Vertices, ignoreIndex: Boolean): List[String] = ???
 

--- a/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/ServerBaseWriterSuite.scala
+++ b/exchange-common/src/test/scala/com/vesoft/exchange/common/writer/ServerBaseWriterSuite.scala
@@ -240,4 +240,5 @@ class ServerBaseWriterSuite extends ServerBaseWriter {
   override def prepare(): Unit = ???
 
   override def close(): Unit = ???
+  
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 206


#### Description:
support writeMode:upsert. we can use it as follows:

we can set the writeMode to UPSERT in config file, and the modify the following files:

in vertex_player.csv
1. add vertex：player201,23,kun
2. modify vertex：player116,34,LeBron James  ->  player116,41,LeBron James

in edge_serve.csv
1. add edge：player201,team200,2019,2025
2. modify edge：player149,team219,2016,2019 -> player149,team219,2016,2025


After running tasks,  we can check the result:

for vertex：
1. FETCH PROP ON player "player201" YIELD properties(vertex);
+------------------------+
| properties(VERTEX)     |
+------------------------+
| {age: 23, name: "kun"} |
+------------------------+
Got 1 rows (time spent 1.872ms/2.522745ms)

Fri, 18 Jul 2025 16:22:07 CST

2. FETCH PROP ON player "player116" YIELD properties(vertex);
+---------------------------------+
| properties(VERTEX)              |
+---------------------------------+
| {age: 41, name: "LeBron James"} |
+---------------------------------+
Got 1 rows (time spent 2.111ms/3.072847ms)

Fri, 18 Jul 2025 16:13:06 CST


for edge：
1. GO FROM "player200"         OVER serve         YIELD properties(edge).start_year, properties(edge).end_year;
+-----------------------------+---------------------------+
| properties(EDGE).start_year | properties(EDGE).end_year |
+-----------------------------+---------------------------+
| 2019                        | 2025                      |
+-----------------------------+---------------------------+
Got 1 rows (time spent 5.876ms/7.279124ms)

Fri, 18 Jul 2025 16:13:30 CST
2. GO FROM "player149"         OVER serve         YIELD properties(edge).start_year, properties(edge).end_year;
+-----------------------------+---------------------------+
| properties(EDGE).start_year | properties(EDGE).end_year |
+-----------------------------+---------------------------+
| 2016                        | 2025                      |
+-----------------------------+---------------------------+
Got 1 rows (time spent 2.868ms/3.760936ms)

Fri, 18 Jul 2025 16:14:06 CST

## How do you solve it?
same with impl of update


